### PR TITLE
Extend the signature generation

### DIFF
--- a/lib/bits_service_client/blob.rb
+++ b/lib/bits_service_client/blob.rb
@@ -28,7 +28,7 @@ module BitsService
     end
 
     def public_download_url
-      signed_url = "#{@public_endpoint}#{self.sign_signature(resource_path(key), @signing_key_secret, @signing_key_id)}"
+      signed_url = "#{@public_endpoint}#{self.sign_signature('GET', resource_path(key), @signing_key_secret, @signing_key_id)}"
 
       response = @private_http_client.head(signed_url, @vcap_request_id)
       validate_response_code!([200, 302], response)
@@ -41,7 +41,7 @@ module BitsService
     end
 
     def public_upload_url
-      "#{@public_endpoint}#{self.sign_signature(resource_path(key), @signing_key_secret, @signing_key_id)}&async=true&verb=put"
+      "#{@public_endpoint}#{self.sign_signature('PUT',resource_path(key), @signing_key_secret, @signing_key_id)}&async=true&verb=put"
     end
 
     def internal_download_url

--- a/lib/bits_service_client/resource_pool.rb
+++ b/lib/bits_service_client/resource_pool.rb
@@ -24,7 +24,7 @@ module BitsService
     end
 
     def signed_matches_url
-      "#{@public_endpoint}#{self.sign_signature('/app_stash/matches', @signed_key_secret, @signed_key_id)}"
+      "#{@public_endpoint}#{self.sign_signature('POST','/app_stash/matches', @signed_key_secret, @signed_key_id)}"
     end
 
     def bundles(resources_json, entries_path)

--- a/lib/util/signature_util.rb
+++ b/lib/util/signature_util.rb
@@ -2,10 +2,10 @@
 
 module BitsService
   module SignatureUtil
-    def sign_signature(resource_path, key_secret, key_id)
+    def sign_signature(method, resource_path, key_secret, key_id)
       expires = seconds_since_the_unix_epoch_with_offset(3600)
       "#{resource_path}?" \
-        "signature=#{OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new, key_secret, "#{expires}#{resource_path} #{key_secret}")}&" \
+        "signature=#{OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new, key_secret, "#{method.upcase} #{resource_path} #{key_secret} #{expires}")}&" \
         "expires=#{expires}&" \
         "AccessKeyId=#{key_id}"
     end

--- a/spec/unit/bits_service_client/signature_util_spec.rb
+++ b/spec/unit/bits_service_client/signature_util_spec.rb
@@ -15,7 +15,8 @@ module BitsService
         resource_path = '/packages/stuff'
         secret = 's3cr3t'
         key_id = 'key1'
-        encoded_signed_url = @util.sign_signature(resource_path, secret, key_id)
+        method = 'get'
+        encoded_signed_url = @util.sign_signature(method ,resource_path, secret, key_id)
         url_query_params = encoded_signed_url.split('?')[1]
         params = url_query_params.split('&')
 


### PR DESCRIPTION
The signature format is now extend with the http methods. Additionally the signature format did also change on the API side so this is also part of this commit. 
[#135220281]